### PR TITLE
Ensure filestore rootpath on query_save

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.rvmrc

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@ require "bundler/gem_tasks"
 require 'rspec/core/rake_task'
 require 'cucumber/rake/task'
 require 'mysql2'
+require 'pg'
 
 desc 'Run RSpec tests'
 RSpec::Core::RakeTask.new(:spec) do |task|
@@ -20,6 +21,8 @@ namespace :db do
   namespace :test do
     desc "Populate the test database"
     task :populate do
+      # MySQL
+      #
       client = Mysql2::Client.new(:host => "localhost", :username => "root")
       client.query "CREATE DATABASE IF NOT EXISTS oculus_test"
       client.query "USE oculus_test"
@@ -36,6 +39,29 @@ namespace :db do
       client.query %[
         INSERT INTO oculus_users (name) VALUES ('Paul'), ('Amy'), ('Peter')
       ]
+
+      client.close
+
+      # Postgres
+      #
+      client = PG::Connection.new(:host => "localhost", :dbname => "postgres")
+      client.query "DROP DATABASE IF EXISTS oculus_test"
+      client.query "CREATE DATABASE oculus_test"
+      client.close
+
+      client = PG::Connection.new(:host => "localhost", :dbname => "oculus_test")
+      client.query %[
+        CREATE TABLE oculus_users (
+          id INT NOT NULL UNIQUE,
+          name VARCHAR(255)
+        );
+      ]
+
+      client.query %[
+        INSERT INTO oculus_users (id, name) VALUES (1, 'Paul'), (2, 'Amy'), (3, 'Peter')
+      ]
+
+      client.close
     end
   end
 end

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,6 @@
 ## Upcoming (pre-1.0)
 
 * Input validation
-* Data download
 
 ## Eventually (1.1 or later)
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,8 @@
 
 ## Upcoming (pre-1.0)
 
-* Input validation
+* Setup instructions
+* New user experience
 
 ## Eventually (1.1 or later)
 

--- a/bin/oculus
+++ b/bin/oculus
@@ -26,6 +26,10 @@ Vegas::Runner.new(Oculus::Server, 'oculus') do |runner, opts, app|
   opts.on("-D", "--database DATABASE", "Database to use") do |db|
     Oculus.connection_options[:database] = db
   end
+  opts.on("-t", "--adapter ADAPTER", "Database adapter") do |adapter|
+    abort "oculus: unknown adapter '#{adapter}'" unless ['mysql', 'postgres', 'pg'].include?(adapter)
+    Oculus.connection_options[:adapter] = adapter
+  end
   opts.on("-d", "--data DIRECTORY", "Data cache path (default: tmp/data)") do |path|
     Oculus.cache_path = path
   end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -9,6 +9,7 @@ Capybara.default_wait_time = 10
 
 Oculus.cache_path = 'tmp/test_cache'
 Oculus.connection_options = {
+  :adapter => 'mysql',
   :host => 'localhost',
   :username => 'root',
   :database => 'oculus_test'

--- a/lib/oculus.rb
+++ b/lib/oculus.rb
@@ -6,7 +6,7 @@ require "oculus/query"
 module Oculus
   extend self
 
-  DEFAULT_CONNECTION_OPTIONS = { :host => 'localhost', :username => 'root' }
+  DEFAULT_CONNECTION_OPTIONS = { :adapter => 'mysql', :host => 'localhost' }
 
   attr_writer :cache_path
 

--- a/lib/oculus/connection.rb
+++ b/lib/oculus/connection.rb
@@ -1,7 +1,17 @@
 require 'oculus/connection/mysql2'
+require 'oculus/connection/postgres'
 
 module Oculus
   module Connection
     class Error < StandardError; end
+
+    def self.connect(options)
+      case options[:adapter]
+      when 'mysql'
+        Mysql2
+      when 'postgres', 'pg'
+        Postgres
+      end.new(options)
+    end
   end
 end

--- a/lib/oculus/connection/mysql2.rb
+++ b/lib/oculus/connection/mysql2.rb
@@ -14,6 +14,10 @@ module Oculus
         raise Connection::Error.new(e.message)
       end
 
+      def kill(id)
+        execute("KILL QUERY #{id}")
+      end
+
       def thread_id
         @connection.thread_id
       end

--- a/lib/oculus/connection/postgres.rb
+++ b/lib/oculus/connection/postgres.rb
@@ -1,0 +1,31 @@
+require 'pg'
+
+module Oculus
+  module Connection
+    class Postgres
+      def initialize(options = {})
+        @connection = ::PG::Connection.new(options[:host],
+                                           options[:port],
+                                           nil, nil,
+                                           options[:database],
+                                           options[:username],
+                                           options[:password])
+      end
+
+      def execute(sql)
+        results = @connection.exec(sql)
+        [results.fields] + results.values if results
+      rescue ::PG::Error => e
+        raise Connection::Error.new(e.message)
+      end
+
+      def kill(id)
+        @connection.execute("SELECT pg_cancel_backend(#{id})")
+      end
+
+      def thread_id
+        @connection.backend_pid
+      end
+    end
+  end
+end

--- a/lib/oculus/query.rb
+++ b/lib/oculus/query.rb
@@ -8,6 +8,7 @@ module Oculus
     attr_accessor :error
     attr_accessor :started_at
     attr_accessor :finished_at
+    attr_accessor :starred
     attr_accessor :thread_id
 
     def initialize(attributes = {})
@@ -23,6 +24,7 @@ module Oculus
         :query       => query,
         :started_at  => started_at,
         :finished_at => finished_at,
+        :starred     => starred,
         :thread_id   => thread_id
       }
       attrs[:error] = error if error

--- a/lib/oculus/query.rb
+++ b/lib/oculus/query.rb
@@ -56,6 +56,14 @@ module Oculus
       complete? && !error
     end
 
+    def to_csv
+      CSV.generate do |csv|
+        results.each do |row|
+          csv << row
+        end
+      end
+    end
+
     class << self
       def create(attributes)
         query = new(attributes)

--- a/lib/oculus/server.rb
+++ b/lib/oculus/server.rb
@@ -21,6 +21,12 @@ module Oculus
       erb :index
     end
 
+    get '/starred' do
+      @queries = Oculus.data_store.starred_queries.map { |q| Oculus::Presenters::QueryPresenter.new(q) }
+
+      erb :starred
+    end
+
     get '/history' do
       @queries = Oculus.data_store.all_queries.map { |q| Oculus::Presenters::QueryPresenter.new(q) }
 
@@ -83,8 +89,9 @@ module Oculus
 
     put '/queries/:id' do
       @query = Oculus::Query.find(params[:id])
-      @query.name   = params[:name]
-      @query.author = params[:author]
+      @query.name    = params[:name]              if params[:name]
+      @query.author  = params[:author]            if params[:author]
+      @query.starred = params[:starred] == "true" if params[:starred]
       @query.save
 
       puts "true"

--- a/lib/oculus/server.rb
+++ b/lib/oculus/server.rb
@@ -66,6 +66,17 @@ module Oculus
       erb :show
     end
 
+    get '/queries/:id/download' do
+      query = Oculus::Query.find(params[:id])
+      timestamp = query.started_at.strftime('%Y%m%d%H%M')
+
+      attachment    "#{timestamp}-query-#{query.id}-results.csv"
+      content_type  "text/csv"
+      last_modified query.finished_at
+
+      query.to_csv
+    end
+
     get '/queries/:id/status' do
       Oculus::Presenters::QueryPresenter.new(Oculus::Query.find(params[:id])).status
     end

--- a/lib/oculus/server.rb
+++ b/lib/oculus/server.rb
@@ -36,7 +36,7 @@ module Oculus
     post '/queries/:id/cancel' do
       query = Oculus::Query.find(params[:id])
       connection = Oculus::Connection::Mysql2.new(Oculus.connection_options)
-      connection.execute("KILL QUERY #{query.thread_id}")
+      connection.kill(query.thread_id)
       [200, "OK"]
     end
 

--- a/lib/oculus/server.rb
+++ b/lib/oculus/server.rb
@@ -35,7 +35,7 @@ module Oculus
 
     post '/queries/:id/cancel' do
       query = Oculus::Query.find(params[:id])
-      connection = Oculus::Connection::Mysql2.new(Oculus.connection_options)
+      connection = Oculus::Connection.connect(Oculus.connection_options)
       connection.kill(query.thread_id)
       [200, "OK"]
     end
@@ -45,7 +45,7 @@ module Oculus
 
       pid = fork do
         query = Oculus::Query.find(query.id)
-        connection = Oculus::Connection::Mysql2.new(Oculus.connection_options)
+        connection = Oculus::Connection.connect(Oculus.connection_options)
         query.execute(connection)
       end
 

--- a/lib/oculus/server/public/css/style.css
+++ b/lib/oculus/server/public/css/style.css
@@ -102,6 +102,18 @@ body {
   margin-top: 1em;
 }
 
+button.star .starred-contents {
+  display: none;
+}
+
+button.starred .starred-contents {
+  display: inline;
+}
+
+button.starred .unstarred-contents {
+  display: none;
+}
+
 #query-properties-form {
   display: none;
 }

--- a/lib/oculus/server/public/js/application.js
+++ b/lib/oculus/server/public/js/application.js
@@ -32,6 +32,22 @@ $(function() {
     });
   });
 
+  $('#query-actions .star').click(function() {
+    var btn = $(this),
+        newState = !btn.hasClass('starred');
+
+    $.ajax({
+      url: this.href,
+      type: 'PUT',
+      data: {
+        'starred': newState
+      },
+      success: function() {
+        btn.toggleClass('starred', newState);
+      }
+    });
+  });
+
   $('#query-actions .edit').click(function() {
     $('#query-properties-form').toggle();
   });

--- a/lib/oculus/server/public/js/application.js
+++ b/lib/oculus/server/public/js/application.js
@@ -84,7 +84,7 @@ QueryEditor.prototype.initCodeMirror = function() {
 QueryEditor.prototype.bindEvents = function() {
   var self = this;
   $(document).on('keydown', 'form', function(e) {
-    if (e.keyCode === 13 && (e.ctrlKey || e.metaKey)) {
+    if ((e.keyCode === 13 && (e.ctrlKey || e.metaKey)) || (e.metaKey && e.altKey && e.keyCode === 82)) {
       e.preventDefault();
 
       // CodeMirror normally saves itself automatically, but since there is no

--- a/lib/oculus/server/views/history.erb
+++ b/lib/oculus/server/views/history.erb
@@ -27,9 +27,3 @@
     <% end %>
   </tbody>
 </table>
-
-<script type="text/javascript">
-  CodeMirror.fromTextArea(document.getElementById('query-field'), {
-    tabSize: 2
-  });
-</script>

--- a/lib/oculus/server/views/index.erb
+++ b/lib/oculus/server/views/index.erb
@@ -6,7 +6,7 @@
   </div>
   <div class="form-actions">
     <input type="submit" class="btn" name="submit" value="Run" />
-    <span class="deemphasized help-inline">Ctrl+&crarr; or &#8984;&crarr;</span>
+    <span class="deemphasized help-inline"><abbr title="Ctrl+Enter">Ctrl+&crarr;</abbr> or <abbr title="Command+Enter">&#8984;&crarr;</abbr></span>
   </div>
 </form>
 

--- a/lib/oculus/server/views/layout.erb
+++ b/lib/oculus/server/views/layout.erb
@@ -20,6 +20,9 @@
             <li<% if @current_tab == 'home' %> class="active"<% end %>>
               <a href="/">Home</a>
             </li>
+            <li<% if @current_tab == 'starred' %> class="active"<% end %>>
+              <a href="/starred">Starred</a>
+            </li>
             <li<% if @current_tab == 'history' %> class="active"<% end %>>
               <a href="/history">History</a>
             </li>

--- a/lib/oculus/server/views/show.erb
+++ b/lib/oculus/server/views/show.erb
@@ -5,6 +5,10 @@
     <i class="icon-pencil"></i>
     Edit
   </button>
+  <a class="btn file<% unless @query.succeeded? && @headers %> disabled<% end %>" href="/queries/<%= @query.id %>/download">
+    <i class="icon-file"></i>
+    Download
+  </a>
 </div>
 
 <dl class="dl-horizontal query-properties">
@@ -67,4 +71,7 @@
 <script type="text/javascript">
   var queryNode = $('pre.cm-s-default');
   CodeMirror.runMode(queryNode.text(), 'mysql', queryNode[0]);
+  $('a.disabled').click(function(e) {
+    e.preventDefault();
+  });
 </script>

--- a/lib/oculus/server/views/show.erb
+++ b/lib/oculus/server/views/show.erb
@@ -1,6 +1,16 @@
 <h1 class="description"><%= @query.description %></h1>
 
 <div id="query-actions">
+  <button class="btn btn-success star<% if @query.starred %> starred<% end %>">
+    <span class="unstarred-contents">
+      <i class="icon-star-empty icon-white"></i>
+      Star
+    </span>
+    <span class="starred-contents">
+      <i class="icon-star icon-white"></i>
+      Starred
+    </span>
+  </button>
   <button class="btn edit<% unless @query.named? %> active<% end %>" data-toggle="button">
     <i class="icon-pencil"></i>
     Edit

--- a/lib/oculus/server/views/starred.erb
+++ b/lib/oculus/server/views/starred.erb
@@ -1,0 +1,29 @@
+<% @current_tab = 'starred' %>
+
+<h2>Starred Queries</h2>
+<table class="table">
+  <thead>
+    <th></th>
+    <th>Timestamp</th>
+    <th>Query</th>
+    <th>Author</th>
+    <th></th>
+  </thead>
+  <tbody id="history">
+    <% @queries.each do |query| %>
+      <tr>
+        <td class="status"><span class="indicator indicator-<%= query.status %>">*</span></td>
+        <td class="date"><%= query.formatted_start_time %></td>
+        <td>
+          <a href="/queries/<%= query.id %>"><%= query.description %></a>
+        </td>
+        <td class="author">
+          <%= query.author %>
+        </td>
+        <td>
+          <a class="delete" href="/queries/<%= query.id %>"><i class="icon-remove"></i></a>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/lib/oculus/storage/file_store.rb
+++ b/lib/oculus/storage/file_store.rb
@@ -1,5 +1,6 @@
 require 'yaml'
 require 'csv'
+require 'fileutils'
 
 module Oculus
   module Storage
@@ -21,6 +22,8 @@ module Oculus
       end
 
       def save_query(query)
+        ensure_root_path
+
         query.id = next_id if query.id.nil?
 
         File.open(filename_for_id(query.id), 'w') do |file|
@@ -150,6 +153,10 @@ module Oculus
 
       def primary_key_path
         File.join(root, 'NEXT_ID')
+      end
+
+      def ensure_root_path
+        FileUtils.mkdir_p root unless File.exists? root
       end
 
       attr_reader :root

--- a/lib/oculus/storage/file_store.rb
+++ b/lib/oculus/storage/file_store.rb
@@ -1,5 +1,6 @@
 require 'yaml'
 require 'csv'
+require 'fileutils'
 
 module Oculus
   module Storage
@@ -15,6 +16,8 @@ module Oculus
       end
 
       def save_query(query)
+        ensure_root_path
+
         query.id = next_id if query.id.nil?
 
         File.open(filename_for_id(query.id), 'w') do |file|
@@ -121,6 +124,10 @@ module Oculus
 
       def primary_key_path
         File.join(root, 'NEXT_ID')
+      end
+
+      def ensure_root_path
+        FileUtils.mkdir_p root unless File.exists? root
       end
 
       attr_reader :root

--- a/lib/oculus/version.rb
+++ b/lib/oculus/version.rb
@@ -1,3 +1,3 @@
 module Oculus
-  VERSION = "0.5.0"
+  VERSION = "0.8.0"
 end

--- a/oculus.gemspec
+++ b/oculus.gemspec
@@ -16,11 +16,13 @@ Gem::Specification.new do |gem|
   gem.version       = Oculus::VERSION
 
   gem.add_runtime_dependency "sinatra", [">= 1.3.0"]
-  gem.add_runtime_dependency "mysql2",  [">= 0.3.11"]
   gem.add_runtime_dependency "vegas",   [">= 0.1.4"]
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "cucumber", [">= 1"]
   gem.add_development_dependency "rspec",    [">= 2"]
   gem.add_development_dependency "capybara", [">= 1"]
+
+  gem.add_development_dependency "mysql2",  [">= 0.3.11"]
+  gem.add_development_dependency "pg",      [">= 0.13.2"]
 end

--- a/spec/connection/mysql2_spec.rb
+++ b/spec/connection/mysql2_spec.rb
@@ -1,6 +1,6 @@
 require 'oculus'
 
-describe Oculus::Connection do
+describe Oculus::Connection::Mysql2 do
   subject { Oculus::Connection::Mysql2.new(:host => 'localhost', :database => 'oculus_test', :username => 'root') }
 
   it "fetches a result set" do

--- a/spec/connection/postgres_spec.rb
+++ b/spec/connection/postgres_spec.rb
@@ -1,0 +1,22 @@
+require 'oculus'
+
+describe Oculus::Connection::Postgres do
+  subject { Oculus::Connection::Postgres.new(:host => 'localhost', :database => 'oculus_test') }
+
+  it "fetches a result set" do
+    subject.execute("SELECT * FROM oculus_users").should == [['id', 'name'],
+                                                             ['1', 'Paul'],
+                                                             ['2', 'Amy'],
+                                                             ['3', 'Peter']]
+  end
+
+  it "raises a Connection::Error on syntax errors" do
+    lambda {
+      subject.execute("FOO BAZ QUUX")
+    }.should raise_error(Oculus::Connection::Error)
+  end
+
+  it "provides the connection's thread_id" do
+    subject.thread_id.should be_an Integer
+  end
+end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -15,7 +15,7 @@ describe Oculus::Connection do
     }
 
     sleep 0.1
-    subject.execute("KILL QUERY #{thread_id}").should be_nil
+    subject.kill(thread_id).should be_nil
   end
 
   it "raises a Connection::Error on syntax errors" do

--- a/spec/file_store_spec.rb
+++ b/spec/file_store_spec.rb
@@ -141,13 +141,17 @@ describe Oculus::Storage::FileStore do
 
     it "round-trips a query to disk when the cache dir does not exist (like when it's a new project!)" do
       subject.save_query(query)
-      subject.load_query(query.id).results.should == query.results
-      subject.load_query(query.id).query.should == query.query
-      subject.load_query(query.id).started_at.should == query.started_at
-      subject.load_query(query.id).finished_at.should == query.finished_at
-      subject.load_query(query.id).author.should == query.author
-      subject.load_query(query.id).id.should == query.id
-      subject.load_query(query.id).thread_id.should == query.thread_id
+      subject.load_query(query.id).should == {
+        :id => query.id,
+        :name => query.name,
+        :author => query.author,
+        :query => query.query,
+        :results => query.results,
+        :thread_id => query.thread_id,
+        :starred => false,
+        :started_at => query.started_at,
+        :finished_at => query.finished_at
+      }
     end
   end
 end

--- a/spec/file_store_spec.rb
+++ b/spec/file_store_spec.rb
@@ -111,4 +111,21 @@ describe Oculus::Storage::FileStore do
       subject.delete_query('..')
     }.should raise_error(ArgumentError)
   end
+
+  context "when cache dir does not exist (like for a new install)" do
+    before do
+      FileUtils.rm_r('tmp/test_cache')
+    end
+
+    it "round-trips a query to disk when the cache dir does not exist (like when it's a new project!)" do
+      subject.save_query(query)
+      subject.load_query(query.id).results.should == query.results
+      subject.load_query(query.id).query.should == query.query
+      subject.load_query(query.id).started_at.should == query.started_at
+      subject.load_query(query.id).finished_at.should == query.finished_at
+      subject.load_query(query.id).author.should == query.author
+      subject.load_query(query.id).id.should == query.id
+      subject.load_query(query.id).thread_id.should == query.thread_id
+    end
+  end
 end

--- a/spec/file_store_spec.rb
+++ b/spec/file_store_spec.rb
@@ -133,4 +133,21 @@ describe Oculus::Storage::FileStore do
       subject.delete_query('..')
     }.should raise_error(ArgumentError)
   end
+
+  context "when cache dir does not exist (like for a new install)" do
+    before do
+      FileUtils.rm_r('tmp/test_cache')
+    end
+
+    it "round-trips a query to disk when the cache dir does not exist (like when it's a new project!)" do
+      subject.save_query(query)
+      subject.load_query(query.id).results.should == query.results
+      subject.load_query(query.id).query.should == query.query
+      subject.load_query(query.id).started_at.should == query.started_at
+      subject.load_query(query.id).finished_at.should == query.finished_at
+      subject.load_query(query.id).author.should == query.author
+      subject.load_query(query.id).id.should == query.id
+      subject.load_query(query.id).thread_id.should == query.thread_id
+    end
+  end
 end

--- a/spec/file_store_spec.rb
+++ b/spec/file_store_spec.rb
@@ -45,6 +45,7 @@ describe Oculus::Storage::FileStore do
       :query => query.query,
       :results => [],
       :thread_id => query.thread_id,
+      :starred => false,
       :started_at => query.started_at,
       :finished_at => query.finished_at
     }
@@ -60,6 +61,7 @@ describe Oculus::Storage::FileStore do
       :query => broken_query.query,
       :results => [],
       :thread_id => broken_query.thread_id,
+      :starred => false,
       :started_at => broken_query.started_at,
       :finished_at => broken_query.finished_at
     }
@@ -74,6 +76,7 @@ describe Oculus::Storage::FileStore do
       :query => query.query,
       :results => query.results,
       :thread_id => query.thread_id,
+      :starred => false,
       :started_at => query.started_at,
       :finished_at => query.finished_at
     }
@@ -97,6 +100,16 @@ describe Oculus::Storage::FileStore do
     subject.save_query(other_query)
 
     subject.all_queries.map(&:results).should == [other_query.results, query.results]
+  end
+
+  it "fetches starred queries" do
+    query.starred = true
+    subject.save_query(query)
+    subject.save_query(other_query)
+
+    results = subject.starred_queries
+    results.map(&:results).should == [query.results]
+    results.first.starred.should be true
   end
 
   it "deletes queries" do

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -82,6 +82,11 @@ describe Oculus::Query do
     query.author.should == 'Paul'
   end
 
+  it "can be starred" do
+    query = Oculus::Query.new(:starred => true)
+    query.starred.should == true
+  end
+
   it "stores new queries in the data store on creation" do
     Oculus.data_store.should_receive(:save_query)
     query = Oculus::Query.create(:results => [['id', 'name'], [1, 'Paul']])

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -137,4 +137,10 @@ describe Oculus::Query do
     query.execute(connection)
     query.succeeded?.should be false
   end
+
+  it "exports to CSV" do
+    query = Oculus::Query.new
+    query.results = [['id', 'name'], [1, 'Paul']]
+    query.to_csv.should == "id,name\n1,Paul\n"
+  end
 end


### PR DESCRIPTION
When a new Oculus project is launched, ensuring the root path exists is important and should be ensured on #save_query. Otherwise, the installee will be greeted with an application failure and be very angry at Oculus (and you, by way of association). Don't end up with people disliking you.
