### PR TITLE
Sequel storage adapter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'sequel'

--- a/lib/oculus/storage/sequel_store.rb
+++ b/lib/oculus/storage/sequel_store.rb
@@ -1,0 +1,84 @@
+require 'sequel'
+require 'csv'
+
+module Oculus
+  module Storage
+    class SequelStore
+      attr_reader :table, :table_name, :db
+
+      def initialize(uri, options = {})
+        @db = Sequel.connect(uri)
+        @table_name = options[:table] || :oculus
+        @table = @db.from(@table_name)
+      end
+
+      def all_queries
+        to_queries table.order(:id.desc)
+      end
+
+      def starred_queries
+        to_queries table.where(:starred => true).order(:id.desc)
+      end
+
+      def save_query(query)
+        attrs = serialize(query)
+        if query.id
+          table.where(:id => query.id).update(attrs)
+        else
+          query.id = table.insert(attrs)
+        end
+      end
+
+      def load_query(id)
+        if query = table.where(:id => id).first
+          deserialize query
+        else
+          raise QueryNotFound, id
+        end
+      end
+
+      def delete_query(id)
+        raise ArgumentError unless id.to_i > 0
+        raise QueryNotFound, id unless table.where(:id => id).delete == 1
+      end
+
+      def create_table
+        db.create_table?(table_name) do
+          primary_key :id
+          Integer :thread_id
+          String :name
+          String :author
+          File :query
+          File :results
+          Time :started_at
+          Time :finished_at
+          TrueClass :starred
+          String :error
+        end
+      end
+
+      def drop_table
+        db.drop_table(table_name)
+      end
+
+      private
+
+      def to_queries(rows)
+        rows.map { |r| Query.new deserialize(r) }
+      end
+
+      def deserialize(row)
+        row[:results] = row[:results] ? CSV.new(row[:results]).to_a : []
+        row.delete(:error) unless row[:error]
+        row
+      end
+
+      def serialize(query)
+        attrs = query.attributes
+        attrs[:starred] ||= false
+        attrs[:results] = query.to_csv if query.results
+        attrs
+      end
+    end
+  end
+end

--- a/lib/oculus/storage/sequel_store.rb
+++ b/lib/oculus/storage/sequel_store.rb
@@ -9,10 +9,15 @@ module Oculus
       def initialize(uri, options = {})
         @uri = uri
         @table_name = options[:table] || :oculus
+        create_table
+      end
+
+      def db
+        Sequel.connect(@uri, :encoding => 'utf8')
       end
 
       def table
-        Sequel.connect(@uri).from(@table_name)
+        db.from(@table_name)
       end
 
       def all_queries

--- a/lib/oculus/storage/sequel_store.rb
+++ b/lib/oculus/storage/sequel_store.rb
@@ -12,61 +12,76 @@ module Oculus
         create_table
       end
 
-      def db
-        Sequel.connect(@uri, :encoding => 'utf8')
+      def with_db
+        db = Sequel.connect(@uri, :encoding => 'utf8')
+        result = yield db
+        db.disconnect
+        result
       end
 
-      def table
-        db.from(@table_name)
+      def with_table
+        with_db { |db| yield db.from(@table_name) }
       end
 
       def all_queries
-        to_queries table.order(:id.desc)
+        with_table do |table|
+          to_queries table.order(:id.desc)
+        end
       end
 
       def starred_queries
-        to_queries table.where(:starred => true).order(:id.desc)
+        with_table do |table|
+          to_queries table.where(:starred => true).order(:id.desc)
+        end
       end
 
       def save_query(query)
         attrs = serialize(query)
-        if query.id
-          table.where(:id => query.id).update(attrs)
-        else
-          query.id = table.insert(attrs)
+        with_table do |table|
+          if query.id
+            table.where(:id => query.id).update(attrs)
+          else
+            query.id = table.insert(attrs)
+          end
         end
       end
 
       def load_query(id)
-        if query = table.where(:id => id).first
-          deserialize query
-        else
-          raise QueryNotFound, id
+        with_table do |table|
+          if query = table.where(:id => id).first
+            deserialize query
+          else
+            raise QueryNotFound, id
+          end
         end
       end
 
       def delete_query(id)
-        raise ArgumentError unless id.to_i > 0
-        raise QueryNotFound, id unless table.where(:id => id).delete == 1
+        with_table do |table|
+          raise ArgumentError unless id.to_i > 0
+          raise QueryNotFound, id unless table.where(:id => id).delete == 1
+        end
       end
 
       def create_table
-        db.create_table?(table_name) do
-          primary_key :id
-          Integer :thread_id
-          String :name
-          String :author
-          String :query
-          String :results
-          Time :started_at
-          Time :finished_at
-          TrueClass :starred
-          String :error
+        with_db do |db|
+          db.create_table?(table_name) do
+            primary_key :id
+            Integer :thread_id
+            String :name
+            String :author
+            String :query
+            String :results
+            Time :started_at
+            Time :finished_at
+            TrueClass :starred
+            String :error
+          end
         end
       end
 
       def drop_table
-        db.drop_table(table_name)
+        with_db { |db| db.drop_table(table_name) }
       end
 
       private

--- a/lib/oculus/storage/sequel_store.rb
+++ b/lib/oculus/storage/sequel_store.rb
@@ -56,8 +56,8 @@ module Oculus
           Integer :thread_id
           String :name
           String :author
-          File :query
-          File :results
+          String :query
+          String :results
           Time :started_at
           Time :finished_at
           TrueClass :starred

--- a/lib/oculus/storage/sequel_store.rb
+++ b/lib/oculus/storage/sequel_store.rb
@@ -4,12 +4,15 @@ require 'csv'
 module Oculus
   module Storage
     class SequelStore
-      attr_reader :table, :table_name, :db
+      attr_reader :table_name
 
       def initialize(uri, options = {})
-        @db = Sequel.connect(uri)
+        @uri = uri
         @table_name = options[:table] || :oculus
-        @table = @db.from(@table_name)
+      end
+
+      def table
+        Sequel.connect(@uri).from(@table_name)
       end
 
       def all_queries

--- a/spec/storage_spec.rb
+++ b/spec/storage_spec.rb
@@ -1,8 +1,7 @@
 require 'oculus'
+require 'oculus/storage/sequel_store'
 
-describe Oculus::Storage::FileStore do
-  subject { Oculus::Storage::FileStore.new('tmp/test_cache') }
-
+shared_examples "storage" do |subject|
   let(:query) do
     Oculus::Query.new(:name      => "All users",
                       :query     => "SELECT * FROM oculus_users",
@@ -27,18 +26,10 @@ describe Oculus::Storage::FileStore do
                       :error     => "You have an error in your SQL syntax")
   end
 
-  before do
-    FileUtils.mkdir_p('tmp/test_cache')
-  end
-
-  after do
-    FileUtils.rm_r('tmp/test_cache')
-  end
-
-  it "round-trips a query with no results to disk" do
+  it "round-trips a query with no results" do
     query = Oculus::Query.new(:name => "Unfinished query", :author => "Me")
-    subject.save_query(query)
-    subject.load_query(query.id).should == {
+    storage.save_query(query)
+    storage.load_query(query.id).should == {
       :id => query.id,
       :name => query.name,
       :author => query.author,
@@ -51,9 +42,9 @@ describe Oculus::Storage::FileStore do
     }
   end
 
-  it "round-trips a query with an error to disk" do
-    subject.save_query(broken_query)
-    subject.load_query(broken_query.id).should == {
+  it "round-trips a query with an error" do
+    storage.save_query(broken_query)
+    storage.load_query(broken_query.id).should == {
       :id => broken_query.id,
       :name => broken_query.name,
       :error => broken_query.error,
@@ -67,9 +58,9 @@ describe Oculus::Storage::FileStore do
     }
   end
 
-  it "round-trips a query to disk" do
-    subject.save_query(query)
-    subject.load_query(query.id).should == {
+  it "round-trips a query" do
+    storage.save_query(query)
+    storage.load_query(query.id).should == {
       :id => query.id,
       :name => query.name,
       :author => query.author,
@@ -83,75 +74,100 @@ describe Oculus::Storage::FileStore do
   end
 
   it "doesn't overwrite an existing query id when saving" do
-    subject.save_query(query)
+    storage.save_query(query)
     original_id = query.id
-    subject.save_query(query)
+    storage.save_query(query)
     query.id.should == original_id
   end
 
   it "raises QueryNotFound for missing queries" do
     lambda {
-      subject.load_query(39827493)
+      storage.load_query(39827493)
     }.should raise_error(Oculus::Storage::QueryNotFound)
   end
 
   it "fetches all queries in reverse chronological order" do
-    subject.save_query(query)
-    subject.save_query(other_query)
+    storage.save_query(query)
+    storage.save_query(other_query)
 
-    subject.all_queries.map(&:results).should == [other_query.results, query.results]
+    storage.all_queries.map(&:results).should == [other_query.results, query.results]
   end
 
   it "fetches starred queries" do
     query.starred = true
-    subject.save_query(query)
-    subject.save_query(other_query)
+    storage.save_query(query)
+    storage.save_query(other_query)
 
-    results = subject.starred_queries
+    results = storage.starred_queries
     results.map(&:results).should == [query.results]
     results.first.starred.should be true
   end
 
   it "deletes queries" do
-    subject.save_query(query)
-    subject.load_query(query.id)[:name].should == query.name
-    subject.delete_query(query.id)
+    storage.save_query(query)
+    storage.load_query(query.id)[:name].should == query.name
+    storage.delete_query(query.id)
 
     lambda {
-      subject.load_query(query.id)
+      storage.load_query(query.id)
     }.should raise_error(Oculus::Storage::QueryNotFound)
   end
 
   it "raises QueryNotFound when deleting a nonexistent query" do
     lambda {
-      subject.delete_query(10983645)
+      storage.delete_query(10983645)
     }.should raise_error(Oculus::Storage::QueryNotFound)
   end
 
   it "sanitizes query IDs" do
     lambda {
-      subject.delete_query('..')
+      storage.delete_query('..')
     }.should raise_error(ArgumentError)
   end
+end
 
-  context "when cache dir does not exist (like for a new install)" do
+describe Oculus::Storage::FileStore do
+  it_behaves_like "storage" do
+    let(:storage) { Oculus::Storage::FileStore.new('tmp/test_cache') }
+
     before do
+      FileUtils.mkdir_p('tmp/test_cache')
+    end
+
+    after do
       FileUtils.rm_r('tmp/test_cache')
     end
 
-    it "round-trips a query to disk" do
-      subject.save_query(query)
-      subject.load_query(query.id).should == {
-        :id => query.id,
-        :name => query.name,
-        :author => query.author,
-        :query => query.query,
-        :results => query.results,
-        :thread_id => query.thread_id,
-        :starred => false,
-        :started_at => query.started_at,
-        :finished_at => query.finished_at
-      }
+    context "when cache dir does not exist (like for a new install)" do
+      before do
+        FileUtils.rm_r('tmp/test_cache')
+      end
+
+      it "round-trips a query to disk" do
+        storage.save_query(query)
+        storage.load_query(query.id).should == {
+          :id => query.id,
+          :name => query.name,
+          :author => query.author,
+          :query => query.query,
+          :results => query.results,
+          :thread_id => query.thread_id,
+          :starred => false,
+          :started_at => query.started_at,
+          :finished_at => query.finished_at
+        }
+      end
+    end
+  end
+end
+
+describe Oculus::Storage::SequelStore do
+  it_behaves_like "storage" do
+    let(:storage) { Oculus::Storage::SequelStore.new('postgres://localhost/oculus_test') }
+
+    before do
+      storage.drop_table
+      storage.create_table
     end
   end
 end


### PR DESCRIPTION
Currently it creates the storage table automatically if it doesn't exist. Let me know if you want me to change configuration sematics, etc.

Usage:

``` ruby
# Gemfile
gem 'sequel'
```

``` ruby
Oculus.data_store = Oculus::Storage::SequelStore.new(ENV['DATABASE_URL'] || 'postgres://localhost/oculus')
```
