### PR TITLE
Fix display of null values

### DIFF
--- a/features/query.feature
+++ b/features/query.feature
@@ -16,6 +16,14 @@ Feature: Users can query the database
     Then I should see 3 rows of results
 
   @javascript
+  Scenario: Null result field
+    Given a query is cached with results:
+      | id | users |
+      | 1  |       |
+    When I load the cached query
+    Then I should see a null result field
+
+  @javascript
   Scenario: Deleting a query
     Given a query is cached with results:
       | id | users |

--- a/features/step_definitions/query_steps.rb
+++ b/features/step_definitions/query_steps.rb
@@ -37,3 +37,9 @@ Then /^I should not see any queries$/ do
     all('li').length.should == 0
   end
 end
+
+Then /^I should see a null result field$/ do
+  within('.results') do
+    all('td.null').length.should == 1
+  end
+end

--- a/lib/oculus/server/public/css/style.css
+++ b/lib/oculus/server/public/css/style.css
@@ -57,6 +57,10 @@ body {
   font-size: 14px;
 }
 
+#results-table td.null {
+  color: grey;
+}
+
 .status .indicator {
   text-indent: -9999px;
   display: inline-block;

--- a/lib/oculus/server/views/index.erb
+++ b/lib/oculus/server/views/index.erb
@@ -86,7 +86,11 @@
         var row = $('<tr></tr>');
 
         for (var j = 0; j < result.length; j++) {
-          row.append($('<td></td>').text(result[j]));
+          if (result[j]) {
+            row.append($('<td></td>').text(result[j]));
+          } else {
+            row.append('<td class="null">null</td>');
+          }
         }
 
         container.append(row);

--- a/lib/oculus/server/views/show.erb
+++ b/lib/oculus/server/views/show.erb
@@ -102,7 +102,11 @@
         var row = $('<tr></tr>');
 
         for (var j = 0; j < result.length; j++) {
-          row.append($('<td></td>').text(result[j]));
+          if (result[j]) {
+            row.append($('<td></td>').text(result[j]));
+          } else {
+            row.append('<td class="null">null</td>');
+          }
         }
 
         container.append(row);


### PR DESCRIPTION
Makes `null` values display properly, instead of shifting the row over by one column.

Side note: I think the display code in `show.erb` and `index.rb` should be extracted out into a shared JS function, but I don't currently have time to do it.
